### PR TITLE
fix: headerText not showing

### DIFF
--- a/src/lib/components/FakeCaptchaButton.tsx
+++ b/src/lib/components/FakeCaptchaButton.tsx
@@ -21,6 +21,7 @@ export const FakeCaptchaButton = (props: FakeCaptchaProps.CaptchaButton) => {
     onClickCheckbox,
     helpText,
     simulateSlow = 1,
+    headerText,
   } = props;
   const [showCaptcha, setShowCaptcha] = useState(false);
   const [captchaPassed, setCaptchaPassed] = useState(false);
@@ -71,6 +72,7 @@ export const FakeCaptchaButton = (props: FakeCaptchaProps.CaptchaButton) => {
           imgTopicUrls={imgTopicUrls}
           helpText={helpText}
           simulateSlow={simulateSlow}
+          headerText={headerText}
         />
       )}
     </>


### PR DESCRIPTION
### Summary
`headerText` was not being passed from the parent component to the header.

### Why this change is needed
Users would be unable to use custom headers.

### How the change was achieved
Passed the prop from `FakeCaptchaButton` to `FakeCAPTCHA`.
