### PR TITLE
style(clickableImage): fixed images not full height of button

### DIFF
--- a/src/lib/components/styles/ImageButtonStyles.ts
+++ b/src/lib/components/styles/ImageButtonStyles.ts
@@ -20,6 +20,7 @@ export const ClickableImage = styled.button<{
   background-size: cover;
   background-color: #f7f7f7;
   width: 100%;
+  height: 100%;
   aspect-ratio: 1 / 1;
 
   cursor: pointer;


### PR DESCRIPTION
### Summary
The image on `<ImageButton>`s was not the full height of the element.

### Why this change is needed
Ensures visual height consistency in tiles.

### How the change was achieved
Added `height: 100%;` to `ClickableImage` styles.

