### PR TITLE
chore: added .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
### Summary
The `.vscode` folder and changes were being added to the repo. I added it to `.gitignore`.

### Why this change is needed
Useless changes were being held in the repo.

### How the change was achieved
Added `.vscode` to `.gitignore`.
