### PR TITLE
Feat/overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,23 @@ A functional, configurable, frontend CAPTCHA with features available to create a
 
 '⚠️' denotes required props.
 
-| ⚠️  | Property                          | Type                              | Default value                                                                              | Description                                                                                 |
-| --- | --------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
-|     | [`captchaTopics`](#captchatopics) | `string[]`                        | [See here](https://github.com/dylandbl/faCAPTCHA/blob/main/src/lib/utils/stringsToFind.ts) | Topics displayed at the top of the CAPTCHA. Does not work with `headerText`.                |
-|     | `cellsWide`                       | `number`                          | `4`                                                                                        | Number of cells in each row.                                                                |
-|     | `cellsTall`                       | `number`                          | `cellsWide`                                                                                | Number of cells in each column.                                                             |
-| ⚠️  | [`imgTopicUrls`](#imgtopicurls)   | [`ImgTopicType[]`](#imgtopictype) | -                                                                                          | Array of image URLs with associated topic tags.                                             |
-|     | `headerText`                      | `string`                          | [See here](#headertext-default-value)                                                      | Used in place of the CAPTCHA header text. Overrides `captchaTopic`.                         |
-|     | `helpText`                        | `string`                          | [See here](#helptext-default-value)                                                        | Used in place of the default help text, shown when the '?' icon is clicked.                 |
+| ⚠️  | Property                          | Type                              | Default value    | Description   |
+| --- | --------------------------------- | --------------------------------- | ---------------- | ------------- |
+|     | [`captchaTopics`](#captchatopics) | `string[]`                        | [See here](https://github.com/dylandbl/faCAPTCHA/blob/main/src/lib/utils/stringsToFind.ts) | Topics displayed at the top of the CAPTCHA. Does not work with `headerText`. |
+|     | `cellsWide`                       | `number`                          | `4`              | Number of cells in each row.                                                                |
+|     | `cellsTall`                       | `number`                          | `cellsWide`      | Number of cells in each column. |
+| ⚠️  | [`imgTopicUrls`](#imgtopicurls)   | [`ImgTopicType[]`](#imgtopictype) | -                | Array of image URLs with associated topic tags. |
+|     | `headerText`                      | `string`                          | [See here](#headertext-default-value) | Used in place of the CAPTCHA header text. Overrides `captchaTopic`. |
+|     | `helpText`                        | `string`                          | [See here](#helptext-default-value) | Used in place of the default help text, shown when the '?' icon is clicked. |
 |     | `minAttempts`                     | `number`                          | `1`                                                                                        | Minimum number of required attempts, regardless of whether the attempts are correct or not. |
-|     | `notARobotText`                   | `string`                          | `"I'm not a robot"`                                                                        | Used in place of the "I'm not a robot" text.                                                |
+|     | `notARobotText`                   | `string`                          | `"I'm not a robot"` | Used in place of the "I'm not a robot" text.                                                |
 |     | `onClickCheckbox`                 | `() => void`                      | -                                                                                          | Called on clicking the checkbox. Does not execute if the CAPTCHA popup is open.             |
 |     | `onClickVerify`                   | `() => void`                      | -                                                                                          | Called on clicking the 'Verify' button.                                                     |
 |     | `onRefresh`                       | `() => void`                      | -                                                                                          | Called on clicking the refresh icon.                                                        |
-| ⚠️  | `onVerificationComplete`          | `() => void`                      | -                                                                                          | Called on successful verification completion.                                               |
-|     | [`simulateSlow`](#simulateslow)   | `0 - 3`                           | `1`                                                                                        | Simulates a slow internet connection speed.                                                 |
-|     | `verifyText`                      | `string`                          | `"verify"`                                                                                 | Text for the 'Verify' button.                                                               |
+| ⚠️  | `onVerificationComplete`          | `() => void`                      | -                | Called on successful verification completion. |
+|     | [`simulateSlow`](#simulateslow)   | `0 - 3`                           | `1`              | Simulates a slow internet connection speed. |
+|     | `uncloseable`                     | `boolean                          | 'false'          | Prevents the CAPTCHA from being closed until verification is complete. |
+|     | `verifyText`                      | `string`                          | `"verify"`       | Text for the 'Verify' button. |
 
 ### `captchaTopics`
 

--- a/example/src/styles/HeaderStyles.ts
+++ b/example/src/styles/HeaderStyles.ts
@@ -16,7 +16,7 @@ export const HeaderDiv = styled.div`
 
   position: fixed;
   top: 0;
-  z-index: 2;
+  z-index: 2000000001; // One more than Google's solution.
 
   > .topNav-ul {
     font-weight: 500;

--- a/src/components/FakeCaptcha/FakeCaptcha.tsx
+++ b/src/components/FakeCaptcha/FakeCaptcha.tsx
@@ -15,6 +15,7 @@ import { RefreshSvg } from "../SvgComponent/SvgComponent";
 import { Label } from "../FakeCaptchaButton/FakeCaptchaButtonStyles";
 import { useCallback } from "react";
 import { Props } from "../../types/index";
+import { OverlayDiv } from "../Overlay/OverlayStyles";
 
 const FakeCAPTCHA = (props: Props.CaptchaWindow) => {
   const {
@@ -31,6 +32,7 @@ const FakeCAPTCHA = (props: Props.CaptchaWindow) => {
     captchaTopics,
     imgTopicUrls,
     helpText,
+    uncloseable = false,
   } = props;
   const initialTopic = captchaTopics
     ? captchaTopics[Math.floor(Math.random() * (captchaTopics.length - 1))]
@@ -162,8 +164,13 @@ const FakeCAPTCHA = (props: Props.CaptchaWindow) => {
     setDisplayInfo(!displayInfo);
   };
 
+  const handleClose = () => {
+    if (!uncloseable) setShowCaptcha(false);
+  };
+
   return (
     <>
+      <OverlayDiv onClick={handleClose} />
       <CaptchaContainerOuter>
         <CaptchaContainer displayInfo={displayInfo}>
           {isLoading ? (

--- a/src/components/FakeCaptcha/FakeCaptchaStyles.ts
+++ b/src/components/FakeCaptcha/FakeCaptchaStyles.ts
@@ -6,7 +6,7 @@ export const CaptchaContainerOuter = styled.div`
   max-width: 332px;
   position: absolute;
   background: white;
-  z-index: 1;
+  z-index: 2000000000; // This is what Google does, so it's okay.
 `;
 export const CaptchaContainer = styled.div<{ displayInfo: boolean }>`
   padding: 8px 8px 16px;

--- a/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
+++ b/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
@@ -19,6 +19,7 @@ export const FakeCaptchaButton = (props: Props.CaptchaButton) => {
     simulateSlow = 1,
     headerText,
     captchaTopics,
+    uncloseable,
   } = props;
   const [showCaptcha, setShowCaptcha] = useState(false);
   const [captchaPassed, setCaptchaPassed] = useState(false);
@@ -71,6 +72,7 @@ export const FakeCaptchaButton = (props: Props.CaptchaButton) => {
           simulateSlow={simulateSlow}
           headerText={headerText}
           captchaTopics={captchaTopics}
+          uncloseable={uncloseable}
         />
       )}
     </>

--- a/src/components/Overlay/OverlayStyles.tsx
+++ b/src/components/Overlay/OverlayStyles.tsx
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled";
+
+export const OverlayDiv = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  top: 0;
+  left: 0;
+  z-index: 2000000000; // This is what Google does, so it's okay.
+`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export namespace Props {
     onClickVerify?: () => void; // Function to execute on clicking 'Verify'.
     onRefresh?: () => void; // Executes on clicking the refresh icon.
     simulateSlow?: 0 | 1 | 2 | 3; // Simulate a slow internet connection.
+    uncloseable?: boolean; // Prevent the CAPTCHA from being closed until verification is complete.
     verifyText?: string; // Text for the 'Verify' button.
   }
 


### PR DESCRIPTION
### Summary
Added a feature to allow closing the CAPTCHA popup by clicking away from it.  Also created a feature to prevent closing the CAPTCHA until it's been completed. Added documentations for new prop.

### Why this change is needed
The CAPTCHA popup could previously not be closed until completion.

### How the change was achieved
* Created an overlay div and a ridiculously large `z-index` for the overlay and popup. Created a `handleClose` for the overlay.
* Set the example project's header to a higher index than the CAPTCHA popups to ensure it sits above them.
* Created an `uncloseable` prop for the CAPTCHA. If true, the CAPTCHA cannot be closed until verification is complete.
* Added section in the docs for `uncloseable` prop.

