### PR TITLE
fix(example): link to 'top' in header incorrect

### DIFF
--- a/example/src/components/Header.tsx
+++ b/example/src/components/Header.tsx
@@ -26,7 +26,7 @@ export const Header = ({ screenWidth }: { screenWidth: number }) => {
       {screenWidth < 1272 && (
         <ul className="topNav-ul">
           <li>
-            <a href="Top">Top</a>
+            <a href="#Top">Top</a>
           </li>
           <li>
             <a href="#Demos">Demos</a>


### PR DESCRIPTION
### Summary
Fixed incorrect link in small screen header in `/example/`.

### Why this change is needed
Instead of redirecting to `/faCAPTCHA#Top`, the link was redirecting to `/Top`, which doesn't exist.

### How the change was achieved
Fixed the `href` in the `<a>`.
