### PR TITLE
fix(styles): captcha button max-width

### DIFF
--- a/src/components/FakeCaptchaButton/FakeCaptchaButtonStyles.tsx
+++ b/src/components/FakeCaptchaButton/FakeCaptchaButtonStyles.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 
 export const CaptchaButton = styled.div`
   min-width: 275px;
+  max-width: 275px;
   height: 48px;
   border-radius: 2px;
   border: 1px solid lightgrey;


### PR DESCRIPTION
### Summary
The `FaCaptchaButton` would occasionally expand beyond its defined width.

### Why this change is needed
The button was sometimes expanding to fill areas, an unwanted behaviour.

### How the change was achieved
Added `max-width` to button styles.
