### PR TITLE
feat(example): added mobile support

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example",
   "homepage": "https://dylandbl.github.io/faCAPTCHA/",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "private": false,
   "dependencies": {
     "@emotion/react": "^11.9.3",

--- a/example/src/sections/ShowRoom.tsx
+++ b/example/src/sections/ShowRoom.tsx
@@ -70,6 +70,7 @@ export const ShowRoom = () => {
     }, 10);
   };
 
+  // This is the limit of what looks good with the original style.
   const smallScreen = useWindowSize() <= 664;
 
   return (

--- a/example/src/sections/ShowRoom.tsx
+++ b/example/src/sections/ShowRoom.tsx
@@ -10,6 +10,7 @@ import { CodeBlock } from "../components/CodeBlock";
 import { useState } from "react";
 import topics from "../exampleData/curatedTopics";
 import { ExternalLinkSvg } from "../components/ExternalLinkSvg";
+import { useWindowSize } from "../utils/hooks";
 
 export const ShowRoom = () => {
   const [showCode, setShowCode] = useState(false);
@@ -69,35 +70,39 @@ export const ShowRoom = () => {
     }, 10);
   };
 
+  const smallScreen = useWindowSize() <= 664;
+
   return (
     <ShowRoomContainer>
-      <div className="codeBlockContainer">
-        <CodeBlock show={showCode}>
-          {`<FaCaptcha
+      {!smallScreen && (
+        <div className="codeBlockContainer">
+          <CodeBlock show={showCode}>
+            {`<FaCaptcha
   onVerificationComplete={}
   imgTopicUrls={}`}
-          {captchaTopicsValue[0] === ""
-            ? ""
-            : `\n  captchaTopics={["${captchaTopicsValue}"]}`}
-          {cellsWideValue === 4 ? "" : `\n  cellsWide={${cellsWideValue}}`}
-          {simulateSlowValue === 1
-            ? ""
-            : `\n  simulateSlow={${simulateSlowValue}}`}
-          {minAttemptsValue === 1
-            ? ""
-            : `\n  minAttempts={${minAttemptsValue}}`}
-          {notARobotTextValue === "I'm not a robot"
-            ? ""
-            : `\n  notARobotText="${notARobotTextValue}"`}
-          {verifyTextValue === "verify"
-            ? ""
-            : `\n  verifyText={${verifyTextValue}}`}
-          {!uncloseableValue ? "" : `\n  uncloseable`}
-          {`\n/>`}
-        </CodeBlock>
-      </div>
+            {captchaTopicsValue[0] === ""
+              ? ""
+              : `\n  captchaTopics={["${captchaTopicsValue}"]}`}
+            {cellsWideValue === 4 ? "" : `\n  cellsWide={${cellsWideValue}}`}
+            {simulateSlowValue === 1
+              ? ""
+              : `\n  simulateSlow={${simulateSlowValue}}`}
+            {minAttemptsValue === 1
+              ? ""
+              : `\n  minAttempts={${minAttemptsValue}}`}
+            {notARobotTextValue === "I'm not a robot"
+              ? ""
+              : `\n  notARobotText="${notARobotTextValue}"`}
+            {verifyTextValue === "verify"
+              ? ""
+              : `\n  verifyText={${verifyTextValue}}`}
+            {!uncloseableValue ? "" : `\n  uncloseable`}
+            {`\n/>`}
+          </CodeBlock>
+        </div>
+      )}
 
-      <FlexContainer>
+      <FlexContainer smallScreen={smallScreen}>
         {showFaCaptcha ? (
           <FaCaptcha
             onVerificationComplete={() => {}}
@@ -129,9 +134,11 @@ export const ShowRoom = () => {
                 <ShowCodeButton onClick={handleResetFields}>
                   (Reset)
                 </ShowCodeButton>{" "}
-                <ShowCodeButton onClick={handleToggleCodeView}>
-                  [{showCode ? "Hide" : "View"} code]
-                </ShowCodeButton>
+                {!smallScreen && (
+                  <ShowCodeButton onClick={handleToggleCodeView}>
+                    [{showCode ? "Hide" : "View"} code]
+                  </ShowCodeButton>
+                )}
               </>
             )}{" "}
             <ShowCodeButton onClick={handleToggleConfig}>

--- a/example/src/styles/FooterStyles.ts
+++ b/example/src/styles/FooterStyles.ts
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 export const FooterContainer = styled.div`
   height: 26px;
   width: calc(100% - 32px);
-  margin: 0 16px;
+  margin: 16px 16px 0;
   background: white;
   border-top: 2px solid lightgrey;
   color: #545454;

--- a/example/src/styles/ShowRoomStyles.ts
+++ b/example/src/styles/ShowRoomStyles.ts
@@ -23,14 +23,15 @@ export const ShowCodeButton = styled.div`
   }
 `;
 
-export const FlexContainer = styled.div`
+export const FlexContainer = styled.div<{ smallScreen?: boolean }>`
   display: flex;
   justify-content: space-evenly;
-  align-items: flex-start;
-  width: 100vw;
+  align-items: ${({ smallScreen }) => (smallScreen ? "center" : "flex-start")};
+  ${({ smallScreen }) => smallScreen && "flex-direction: column-reverse;"}
+  width: 100%;
   max-width: 1000px;
   min-height: 280px;
-  margin: 20px auto 0px;
+  margin: ${({ smallScreen }) => (smallScreen ? "48px" : "20px")} auto 0px;
 `;
 
 export const InputsContainer = styled.div<{ show: boolean }>`


### PR DESCRIPTION
### Summary
Added a mobile version of the demo website.

### Why this change is needed
Content scrolled off the screen when viewing the original site.

### How the change was achieved
Changed config and component flex-direction to `column-reverse`. Hid the `CodeBlock` when viewing on mobile.
