### PR TITLE
fix(example): tab title

### DIFF
--- a/example/public/index.html
+++ b/example/public/index.html
@@ -24,20 +24,10 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>faCAPTCHA</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <noscript>Please enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>


### PR DESCRIPTION
### Summary
Changed the `title` of the demo website tab.

### Why this change is needed
The previous title was the default "React App".

### How the change was achieved
Changed the value between the `<title>` tags in `/example/src/public/index.html`.
