### PR TITLE
fix(style): 'Copied!' notice starts too low

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example",
   "homepage": "https://dylandbl.github.io/faCAPTCHA/",
-  "version": "3.1.2",
+  "version": "3.2.1",
   "private": false,
   "dependencies": {
     "@emotion/react": "^11.9.3",

--- a/example/src/styles/CodeBlockStyles.ts
+++ b/example/src/styles/CodeBlockStyles.ts
@@ -48,7 +48,7 @@ export const CopiedNotice = styled.span`
 
   @keyframes copiedAnimation {
     from {
-      top: -16px;
+      top: -22px;
       opacity: 1;
     }
     to {


### PR DESCRIPTION
### Summary
The 'Copied!' notice started too low.
Bumped the version number.

### Why this change is needed
The notice started behind the code block, obscured.

### How the change was achieved
Decreased `top` further.
