### PR TITLE
feat: allowRetry for captcha

### DIFF
--- a/example/src/sections/ShowRoom.tsx
+++ b/example/src/sections/ShowRoom.tsx
@@ -33,6 +33,7 @@ export const ShowRoom = () => {
     useState("I'm not a robot");
   const [captchaTopicsValue, setCaptchaTopicsValue] = useState([""]);
   const [verifyTextValue, setVerifyTextValue] = useState("verify");
+  const [allowRetryValue, setAlowRetryValue] = useState(true);
 
   const handleSimulateSlowChange = (value: string) =>
     setSimulateSlowValue(Number(value));
@@ -53,6 +54,8 @@ export const ShowRoom = () => {
     setCaptchaTopicsValue([value]);
 
   const handleVerifyTextChange = (value: string) => setVerifyTextValue(value);
+
+  const handleAllowRetry = (value: boolean) => setAlowRetryValue(value);
 
   const handleResetFields = () => {
     setSimulateSlowValue(0);
@@ -97,6 +100,7 @@ export const ShowRoom = () => {
             {verifyTextValue === "verify"
               ? ""
               : `\n  verifyText={${verifyTextValue}}`}
+            {!allowRetryValue ? "" : `\n  allowRetry`}
             {!uncloseableValue ? "" : `\n  uncloseable`}
             {`\n/>`}
           </CodeBlock>
@@ -106,6 +110,7 @@ export const ShowRoom = () => {
       <FlexContainer smallScreen={smallScreen}>
         {showFaCaptcha ? (
           <FaCaptcha
+            allowRetry={allowRetryValue}
             onVerificationComplete={() => {}}
             imgTopicUrls={imagesArr2}
             captchaTopics={
@@ -147,6 +152,20 @@ export const ShowRoom = () => {
             </ShowCodeButton>
           </div>
           <InputsContainer show={showConfig}>
+            <p>
+              For a full list of features and API information, see the{" "}
+              <a
+                className="fancy-a"
+                href="https://github.com/dylandbl/faCAPTCHA#api"
+                rel="noreferrer"
+                title="https://github.com/dylandbl/faCAPTCHA#api"
+                target="_blank"
+              >
+                repo on Github
+                <ExternalLinkSvg />
+              </a>
+              .
+            </p>
             <div className="inputsInnerContainer">
               <input
                 className="num-input"
@@ -185,6 +204,18 @@ export const ShowRoom = () => {
                 onChange={(e) => handleMinAttemptsChange(e.target.value)}
               />
               <label htmlFor="minAttempts">Minimum number of attempts</label>
+              <br />
+
+              <input
+                type="checkbox"
+                id="allowRetry"
+                name="allowRetry"
+                checked={allowRetryValue}
+                onChange={(e) => handleAllowRetry(e.target.checked)}
+              />
+              <label htmlFor="uncloseable">
+                Allow retries after verification
+              </label>
               <br />
 
               <input
@@ -240,21 +271,6 @@ export const ShowRoom = () => {
                 onChange={(e) => handleVerifyTextChange(e.target.value)}
               />
               <br />
-
-              <p>
-                For a full list of features and API information, see the{" "}
-                <a
-                  className="fancy-a"
-                  href="https://github.com/dylandbl/faCAPTCHA#api"
-                  rel="noreferrer"
-                  title="https://github.com/dylandbl/faCAPTCHA#api"
-                  target="_blank"
-                >
-                  repo on Github
-                  <ExternalLinkSvg />
-                </a>
-                .
-              </p>
             </div>
           </InputsContainer>
         </div>

--- a/example/src/styles/ShowRoomStyles.ts
+++ b/example/src/styles/ShowRoomStyles.ts
@@ -31,7 +31,7 @@ export const FlexContainer = styled.div<{ smallScreen?: boolean }>`
   width: 100%;
   max-width: 1000px;
   min-height: 280px;
-  margin: ${({ smallScreen }) => (smallScreen ? "48px" : "20px")} auto 0px;
+  margin: ${({ smallScreen }) => (smallScreen ? "48px" : "36px")} auto 0px;
 `;
 
 export const InputsContainer = styled.div<{ show: boolean }>`
@@ -42,7 +42,7 @@ export const InputsContainer = styled.div<{ show: boolean }>`
   ${({ show }) =>
     show
       ? css`
-          height: 290px;
+          height: 335px;
         `
       : css`
           height: 0;
@@ -69,7 +69,7 @@ export const InputsContainer = styled.div<{ show: boolean }>`
   }
 
   p {
-    margin: 6px 0 0;
+    margin: 0 0 6px;
 
     .fancy-a {
       text-decoration: none;

--- a/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
+++ b/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useState } from "react";
+import { useState } from "react";
 import { CaptchaButton, CheckboxDiv, Label } from "./FakeCaptchaButtonStyles";
 import FakeCAPTCHA from "../FakeCaptcha/FakeCaptcha";
 import { useEffect } from "react";
@@ -6,6 +6,7 @@ import { Props } from "../../types/index";
 
 export const FakeCaptchaButton = (props: Props.CaptchaButton) => {
   const {
+    allowRetry = false,
     notARobotText = "I'm not a robot",
     onClickVerify,
     onVerificationComplete,
@@ -26,10 +27,16 @@ export const FakeCaptchaButton = (props: Props.CaptchaButton) => {
   const [checked, setChecked] = useState(false);
   const poweredByText = "Powered by faCAPTCHA";
 
-  const handleClick = (e: MouseEvent) => {
-    e.preventDefault();
-    setShowCaptcha(true);
-    if (showCaptcha && onClickCheckbox) onClickCheckbox();
+  // Handle clicking the large checkbox.
+  const handleClick = () => {
+    if (allowRetry && checked) setChecked(false);
+
+    if (!captchaPassed || allowRetry) {
+      setCaptchaPassed(false);
+      setShowCaptcha(true);
+    }
+
+    if (!showCaptcha && onClickCheckbox) onClickCheckbox();
   };
 
   // Delays displaying the checkmark.
@@ -45,7 +52,7 @@ export const FakeCaptchaButton = (props: Props.CaptchaButton) => {
       <CaptchaButton>
         <CheckboxDiv>
           <input
-            onClick={(e) => handleClick(e)}
+            onClick={handleClick}
             type="checkbox"
             id="captcha-checkbox"
             name="fake-captcha-checkbox"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,7 @@ export namespace Props {
   }
 
   export interface CaptchaButton extends SharedProps {
+    allowRetry?: boolean; // Allows the users to retry the CAPTCHA if they press the checkmark again.
     notARobotText?: string; // Used in place of "I'm not a robot".
     onClickCheckbox?: () => void; // Executes on clicking the checkbox, does not execute if the CAPTCHA popup is open.
     onVerificationComplete: () => void; // Sets verified state on completion.


### PR DESCRIPTION
### Summary
1. Implements #28. Also allows developers to enable or disable the feature in their own implementations.
2. Moved link to API info to top of config in demo site.

### Why this change is needed
1. In the demo site, when users wanted to try new configurations, clicking on the CAPTCHA again would not remove the checkmark. It seemed like a mistake, even though in normal settings, it would not be. This implementation also allows the developer to disable or enable retries.
2. Clearer, more immediate access to info.

### What was done
* Added new prop (`allowRetry`) to enable or disable the feature.
* Changed `handleClick` in `FakeCaptchaButton` to check for `allowRetry`.
* Removed unneeded `preventDefault()` from `handleClick`.
* Implemented feature in the demo site CAPTCHA.