### PR TITLE
style(checkbox): changed cursor: pointer to default style

### DIFF
--- a/src/components/FakeCaptchaButton/FakeCaptchaButtonStyles.tsx
+++ b/src/components/FakeCaptchaButton/FakeCaptchaButtonStyles.tsx
@@ -24,7 +24,6 @@ export const CheckboxDiv = styled.div`
   input {
     height: 24px;
     width: 24px;
-    cursor: pointer;
     margin-right: 10px;
   }
 `;


### PR DESCRIPTION
### Summary
Changed the pointer style to default.

### Why this change is needed
Makes the pointer more unified with normal checkboxes, as they do not user `cursor: pointer` by default.

### What was done
Removed `cursor: pointer` from checkbox styles.
