### PR TITLE
Feat/max attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <img src="https://user-images.githubusercontent.com/48745406/176952369-fa0f699b-a5f9-4ecc-8ebb-ef49a44ee4a1.png" alt="Screenshot of faCAPTCHA" align="left"> 
 
-<br /><br /><br /><br /><br /><br />
+<br /><br /><br /><br /><br />
   
 [**fey**-**kap**-ch*uh*]
 
@@ -20,19 +20,22 @@ A functional, configurable, frontend CAPTCHA for React, with features available 
 | --- | --------------------------------- | --------------------------------- | ---------------- | ------------- |
 |     | `allowRetry`                      | `boolean`                         | `false`          | Allows the user to retry the CAPTCHA after verification is complete. |
 |     | [`captchaTopics`](#captchatopics) | `string[]`                        | [See here](https://github.com/dylandbl/faCAPTCHA/blob/main/src/lib/utils/stringsToFind.ts) | Topics displayed at the top of the CAPTCHA. Does not work with `headerText`. |
-|     | `cellsWide`                       | `number`                          | `4`              | Number of cells in each row.                                                                |
+|     | `cellsWide`                       | `number`                          | `4`              | Number of cells in each row. |
 |     | `cellsTall`                       | `number`                          | `cellsWide`      | Number of cells in each column. |
+|     | `disabled`                        | 'boolean'                         | `false`          | Disables the CAPTCHA, preventing users from attempting verification. `disabled` is `true` if the user exceeds `maxAttempts`. |
 | ⚠️  | [`imgTopicUrls`](#imgtopicurls)   | [`ImgTopicType[]`](#imgtopictype) | -                | Array of image URLs with associated topic tags. |
 |     | `headerText`                      | `string`                          | [See here](#headertext-default-value) | Used in place of the CAPTCHA header text. Overrides `captchaTopic`. |
 |     | `helpText`                        | `string`                          | [See here](#helptext-default-value) | Used in place of the default help text, shown when the '?' icon is clicked. |
-|     | `minAttempts`                     | `number`                          | `1`                                                                                        | Minimum number of required attempts, regardless of whether the attempts are correct or not. |
-|     | `notARobotText`                   | `string`                          | `"I'm not a robot"` | Used in place of the "I'm not a robot" text.                                                |
-|     | `onClickCheckbox`                 | `() => void`                      | -                                                                                          | Called on clicking the checkbox. Does not execute if the CAPTCHA popup is open.             |
-|     | `onClickVerify`                   | `() => void`                      | -                                                                                          | Called on clicking the 'Verify' button.                                                     |
-|     | `onRefresh`                       | `() => void`                      | -                                                                                          | Called on clicking the refresh icon.                                                        |
+|     | `maxAttempts`                     | `number`                          | `8`              | Maximum number of attempts. If exceeded, `disabled` is set to `true` and `onMaxAttempts` is called. |
+|     | `minAttempts`                     | `number`                          | `1`              | Minimum number of required attempts, regardless of whether the attempts are correct or not. |
+|     | `notARobotText`                   | `string`                          | `"I'm not a robot"` | Used in place of the "I'm not a robot" text. |
+|     | `onClickCheckbox`                 | `() => void`                      | -                | Called on clicking the checkbox. Does not execute if the CAPTCHA popup is open. |
+|     | `onClickVerify`                   | `() => void`                      | -                | Called on clicking the 'Verify' button. |
+|     | `onMaxAttempts`                   | `() => void`                      | -                | Called when `maxAttempts` is exceeded. |
+|     | `onRefresh`                       | `() => void`                      | -                | Called on clicking the refresh icon. |
 | ⚠️  | `onVerificationComplete`          | `() => void`                      | -                | Called on successful verification completion. |
 |     | [`simulateSlow`](#simulateslow)   | `0 - 3`                           | `1`              | Simulates a slow internet connection speed. |
-|     | `uncloseable`                     | `boolean`                          | `false`          | Prevents the CAPTCHA from being closed until verification is complete. |
+|     | `uncloseable`                     | `boolean`                         | `false`          | Prevents the CAPTCHA from being closed until verification is complete. |
 |     | `verifyText`                      | `string`                          | `"verify"`       | Text for the 'Verify' button. |
 
 ### `captchaTopics`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facaptcha",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "React CAPTCHA, but it's fun",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/src/components/FakeCaptcha/FakeCaptcha.tsx
+++ b/src/components/FakeCaptcha/FakeCaptcha.tsx
@@ -17,7 +17,7 @@ import { useCallback } from "react";
 import { Props } from "../../types/index";
 import { OverlayDiv } from "../Overlay/OverlayStyles";
 
-const FakeCAPTCHA = (props: Props.CaptchaWindow) => {
+const FaCAPTCHA = (props: Props.CaptchaWindow) => {
   const {
     verifyText = "verify",
     onClickVerify,
@@ -245,4 +245,4 @@ const FakeCAPTCHA = (props: Props.CaptchaWindow) => {
   );
 };
 
-export default FakeCAPTCHA;
+export default FaCAPTCHA;

--- a/src/components/FakeCaptcha/FakeCaptcha.tsx
+++ b/src/components/FakeCaptcha/FakeCaptcha.tsx
@@ -29,6 +29,9 @@ const FakeCAPTCHA = (props: Props.CaptchaWindow) => {
     setCaptchaPassed,
     setShowCaptcha,
     minAttempts = 1,
+    maxAttempts = 8,
+    onMaxAttempts,
+    setDisabled,
     captchaTopics,
     imgTopicUrls,
     helpText,
@@ -146,8 +149,22 @@ const FakeCAPTCHA = (props: Props.CaptchaWindow) => {
     if (!isLoading) {
       if (onClickVerify) onClickVerify();
 
+      // If user has met the max number of attempts...
+      if (currentAttempt >= maxAttempts) {
+        if (onMaxAttempts) onMaxAttempts();
+
+        setCaptchaPassed(false);
+        setShowCaptcha(false);
+        // Lock the verification component.
+        setDisabled(true);
+      }
+
       // If no attempts remaining and verification successful...
-      if (currentAttempt >= minAttempts && verify()) {
+      if (
+        currentAttempt >= minAttempts &&
+        currentAttempt <= maxAttempts &&
+        verify()
+      ) {
         setIsLoading(true);
         setTimeout(() => {
           setCaptchaPassed(true);

--- a/src/components/FakeCaptcha/FakeCaptcha.tsx
+++ b/src/components/FakeCaptcha/FakeCaptcha.tsx
@@ -29,7 +29,7 @@ const FakeCAPTCHA = (props: Props.CaptchaWindow) => {
     setCaptchaPassed,
     setShowCaptcha,
     minAttempts = 1,
-    maxAttempts = 8,
+    maxAttempts,
     onMaxAttempts,
     setDisabled,
     captchaTopics,
@@ -37,6 +37,17 @@ const FakeCAPTCHA = (props: Props.CaptchaWindow) => {
     helpText,
     uncloseable = false,
   } = props;
+  // If maxAttempts is undefined, maxAttempts can be min + 8.
+  // If maxAttempts is defined but less than minAttempts, throw error and disable the CAPTCHA.
+  let maximumAttempts = 8;
+  try {
+    if (!maxAttempts) maximumAttempts += minAttempts;
+    if (maxAttempts && maxAttempts < minAttempts)
+      throw "Error: 'maxAttempts' cannot be less than 'minAttempts'";
+  } catch (e) {
+    console.error(e);
+    setShowCaptcha(false);
+  }
   const initialTopic = captchaTopics
     ? captchaTopics[Math.floor(Math.random() * (captchaTopics.length - 1))]
     : randomCaptchaTopic() ?? "string";
@@ -150,7 +161,7 @@ const FakeCAPTCHA = (props: Props.CaptchaWindow) => {
       if (onClickVerify) onClickVerify();
 
       // If user has met the max number of attempts...
-      if (currentAttempt >= maxAttempts) {
+      if (currentAttempt >= maximumAttempts) {
         if (onMaxAttempts) onMaxAttempts();
 
         setCaptchaPassed(false);
@@ -162,7 +173,7 @@ const FakeCAPTCHA = (props: Props.CaptchaWindow) => {
       // If no attempts remaining and verification successful...
       if (
         currentAttempt >= minAttempts &&
-        currentAttempt <= maxAttempts &&
+        currentAttempt <= maximumAttempts &&
         verify()
       ) {
         setIsLoading(true);

--- a/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
+++ b/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
@@ -9,7 +9,7 @@ import FakeCAPTCHA from "../FakeCaptcha/FakeCaptcha";
 import { useEffect } from "react";
 import { Props } from "../../types/index";
 
-export const FakeCaptchaButton = (props: Props.CaptchaButton) => {
+export const FaCaptchaButton = (props: Props.CaptchaButton) => {
   const {
     allowRetry = false,
     notARobotText = "I'm not a robot",

--- a/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
+++ b/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
@@ -63,13 +63,13 @@ export const FakeCaptchaButton = (props: Props.CaptchaButton) => {
           <CheckboxInput
             onClick={handleClick}
             type="checkbox"
-            id="facaptcha-checkbox"
-            name="facaptcha-checkbox"
+            id="captcha-checkbox"
+            name="facaptcha-Checkbox"
             checked={checked}
             onChange={() => {}}
             disabled={isDisabled}
           />
-          <label htmlFor="facaptcha-checkbox">{notARobotText}</label>
+          <label htmlFor="">{notARobotText}</label>
         </CheckboxDiv>
         <Label>{poweredByText}</Label>
       </CaptchaButton>

--- a/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
+++ b/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
-import { CaptchaButton, CheckboxDiv, Label } from "./FakeCaptchaButtonStyles";
+import {
+  CaptchaButton,
+  CheckboxDiv,
+  CheckboxInput,
+  Label,
+} from "./FakeCaptchaButtonStyles";
 import FakeCAPTCHA from "../FakeCaptcha/FakeCaptcha";
 import { useEffect } from "react";
 import { Props } from "../../types/index";
@@ -12,19 +17,23 @@ export const FakeCaptchaButton = (props: Props.CaptchaButton) => {
     onVerificationComplete,
     verifyText,
     minAttempts,
+    maxAttempts,
     cellsWide,
     cellsTall,
     imgTopicUrls,
     onClickCheckbox,
+    onMaxAttempts,
     helpText,
     simulateSlow = 1,
     headerText,
     captchaTopics,
     uncloseable,
+    disabled = false,
   } = props;
   const [showCaptcha, setShowCaptcha] = useState(false);
   const [captchaPassed, setCaptchaPassed] = useState(false);
   const [checked, setChecked] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(disabled);
   const poweredByText = "Powered by faCAPTCHA";
 
   // Handle clicking the large checkbox.
@@ -51,21 +60,24 @@ export const FakeCaptchaButton = (props: Props.CaptchaButton) => {
     <>
       <CaptchaButton>
         <CheckboxDiv>
-          <input
+          <CheckboxInput
             onClick={handleClick}
             type="checkbox"
-            id="captcha-checkbox"
-            name="fake-captcha-checkbox"
+            id="facaptcha-checkbox"
+            name="facaptcha-checkbox"
             checked={checked}
             onChange={() => {}}
+            disabled={isDisabled}
           />
-          {notARobotText}
+          <label htmlFor="facaptcha-checkbox">{notARobotText}</label>
         </CheckboxDiv>
         <Label>{poweredByText}</Label>
       </CaptchaButton>
-      {showCaptcha && (
+      {showCaptcha && !isDisabled && (
         <FakeCAPTCHA
           minAttempts={minAttempts}
+          maxAttempts={maxAttempts}
+          onMaxAttempts={onMaxAttempts}
           poweredByText={poweredByText}
           captchaPassed={captchaPassed}
           setCaptchaPassed={setCaptchaPassed}
@@ -80,6 +92,7 @@ export const FakeCaptchaButton = (props: Props.CaptchaButton) => {
           headerText={headerText}
           captchaTopics={captchaTopics}
           uncloseable={uncloseable}
+          setDisabled={setIsDisabled}
         />
       )}
     </>

--- a/src/components/FakeCaptchaButton/FakeCaptchaButtonStyles.tsx
+++ b/src/components/FakeCaptchaButton/FakeCaptchaButtonStyles.tsx
@@ -20,12 +20,14 @@ export const CheckboxDiv = styled.div`
   align-items: center;
   font-weight: 500;
   font-size: 0.95rem;
+`;
 
-  input {
-    height: 24px;
-    width: 24px;
-    margin-right: 10px;
-  }
+export const CheckboxInput = styled.input`
+  height: 24px;
+  width: 24px;
+  margin-right: 10px;
+
+  ${({ disabled }) => disabled && "cursor: not-allowed;"}
 `;
 
 export const Label = styled.div`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,10 @@
 import Props from "./types/index";
-import { FakeCaptchaButton } from "./components/FakeCaptchaButton/FakeCaptchaButton";
+import { FaCaptchaButton } from "./components/FakeCaptchaButton/FakeCaptchaButton";
 
 const FaCaptcha = (props: Props.CaptchaButton) => {
   return (
     <span style={{ boxSizing: "border-box" }}>
-      <FakeCaptchaButton {...props} />
+      <FaCaptchaButton {...props} />
     </span>
   );
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,9 @@ export namespace Props {
     imgTopicUrls: ImgTopicType[]; // Array of image URLs with associated tags. The tags are compared to captchaTopics and case and spelling must match exactly. The images will be displayed in order.
     helpText?: string; // An alternative to the default help text, shown when the '?' icon is clicked.
     minAttempts?: number; // The minimum number of required attempts, regardless of whether the attempts are correct or not.
+    maxAttempts?: number; // The maximum number of attempts that can be made before being denied access. Must be greater than or equal to minAttempts.
     onClickVerify?: () => void; // Function to execute on clicking 'Verify'.
+    onMaxAttempts?: () => void; // Function called when the user has met the maximum number of attempts.
     onRefresh?: () => void; // Executes on clicking the refresh icon.
     simulateSlow?: 0 | 1 | 2 | 3; // Simulate a slow internet connection.
     uncloseable?: boolean; // Prevent the CAPTCHA from being closed until verification is complete.
@@ -21,6 +23,7 @@ export namespace Props {
 
   export interface CaptchaButton extends SharedProps {
     allowRetry?: boolean; // Allows the users to retry the CAPTCHA if they press the checkmark again.
+    disabled?: boolean; // Disables the checkbox and disallows the user to complete verification.
     notARobotText?: string; // Used in place of "I'm not a robot".
     onClickCheckbox?: () => void; // Executes on clicking the checkbox, does not execute if the CAPTCHA popup is open.
     onVerificationComplete: () => void; // Sets verified state on completion.
@@ -31,6 +34,7 @@ export namespace Props {
     captchaPassed: boolean;
     setCaptchaPassed: (value: boolean) => void;
     setShowCaptcha: (value: boolean) => void;
+    setDisabled: (value: boolean) => void;
   }
 }
 


### PR DESCRIPTION
### Summary
1. Implements feature suggestion from **[FEAT] Maximum number of attempts** #31. Includes updates to documentation.
2. Updated component names from `FakeCaptcha...` to `FaCaptcha`.

### Why this change is needed
1. Prevents brute-force attempts at solving the CAPTCHA.
2. Prevents confusion if errors or warnings are generated.

### What was done
* Added prop (`maxAttempts`) for configurable number of maximum attempts with a default of 8.
* Added prop (`onMaxAttempts`) for a function to be called when a user has exceeded the maximum number of attempts (i.e. they've failed the CAPTCHA).
* The CAPTCHA checkbox now becomes disabled if `maxAttempts` is exceeded. If disabled, the cursor is now `not-allowed` on the checkbox.
* If `maxAttempts` is less than `minAttempts`, an error will be thrown.
* Added `disabled` prop so the checkbox can be disabled by default, if needed.
* Updated docs with new prop information.
* Minor version bump.
