### PR TITLE
fix: @emotion dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facaptcha",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React CAPTCHA, but it's fun",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
-  "devDependencies": {
+  "dependencies": {
     "@emotion/react": "^11.9.3",
-    "@emotion/styled": "^11.9.3",
+    "@emotion/styled": "^11.9.3"
+  },
+  "devDependencies": {
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
     "typescript": "^4.7.4"


### PR DESCRIPTION
### Summary
When downloaded into a project, an error would be thrown if the project did not have `@emotion/styled` and `@emotion/react` installed as dependencies. 

### Why this change is needed
Creates errors when added to other projects.

### What was done
Moved `@emotion/styled` and `@emotion/react` from `devDependencies` to `dependencies`.
