### PR TITLE
fix: empty array in `imgTopicUrls` crashes app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facaptcha",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "React CAPTCHA, but it's fun",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/src/components/FakeCaptcha/FakeCaptcha.tsx
+++ b/src/components/FakeCaptcha/FakeCaptcha.tsx
@@ -94,18 +94,18 @@ const FaCAPTCHA = (props: Props.CaptchaWindow) => {
           <ImageButton
             key={`${x}-${y}`}
             imageKey={`${x}-${y}`}
-            url={imgTopicUrls[index].url}
-            topics={imgTopicUrls[index].topics}
+            url={imgTopicUrls[index]?.url}
+            topics={imgTopicUrls[index]?.topics}
             handleSelection={handleImageSelection}
           />
         );
 
         // Later, on verification, we can compare selected image keys to keys in this array.
-        if (imgTopicUrls[index].topics.includes(captchaTopic))
+        if (imgTopicUrls[index]?.topics?.includes(captchaTopic))
           correctSelectionKeys.push(`${x}-${y}`);
 
         // Handle indexing depending on array size.
-        if (index >= imgTopicUrls.length - 1) index = 0;
+        if (index >= imgTopicUrls?.length - 1) index = 0;
         else index++;
       }
     }


### PR DESCRIPTION
### Summary
Fixes bug described in #39.

### Why this change is needed
The bug caused app crashing.

### What was done
* Added optional chaining operators in the function that accesses the `imgTopicUrls` array.
* Patch bump