### PR TITLE
fix(ci): package-ecosystem from `yarn` to `npm`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "yarn" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
### Summary
The `package-ecosystem` was listed as `yarn` when it should have been `npm`.

### Why this change is needed
I don't believe @dependabot could look for version updates on an unrecognised package exosystem.

### What was done
Changed `package-ecosystem: "yarn"` to `package-ecosystem: "npm"`.
