### PR TITLE
chore: update eslint, fix: @typescript-eslint/no-namespace

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,8 +6,8 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:@typescript-eslint/recommended",
-    "react-hooks",
     "plugin:jsx-a11y/recommended"
   ],
   "parser": "@typescript-eslint/parser",
@@ -18,15 +18,30 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint", "jsx-a11y"],
+  "plugins": [
+    "react",
+    "@typescript-eslint",
+    "jsx-a11y",
+    "@emotion",
+    "react-hooks"
+  ],
   "rules": {
-    "indent": ["error", 2],
-    "quotes": ["error", "double"],
     "semi": ["error", "always"],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "off",
-    "no-ternary": "error",
+    "no-nested-ternary": "error",
     "no-lonely-if": "error",
-    "no-console": ["warn", { "allow": ["warn", "error"] }]
+    "no-else-return": "error",
+    "no-console": ["warn", { "allow": ["warn", "error"] }],
+    "dot-notation": "error",
+    "react/jsx-key": "error",
+    "jsx-a11y/anchor-is-valid": "error",
+    "jsx-a11y/click-events-have-key-events": "error",
+    "jsx-a11y/no-static-element-interactions": "error"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "yarn build:esm && yarn build:cjs",
     "build:esm": "tsc",
     "build:cjs": "tsc --module commonjs --outDir lib/cjs",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "eslint": "eslint src/**"
   },
   "peerDependencies": {
     "react": "^18.2.0",
@@ -22,6 +23,7 @@
     "@emotion/styled": "^11.10.0"
   },
   "devDependencies": {
+    "@emotion/eslint-plugin": "^11.10.0",
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
     "@typescript-eslint/eslint-plugin": "^5.34.0",
@@ -29,7 +31,7 @@
     "eslint": "^8.22.0",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-react": "^7.30.1",
-    "react-hooks": "^1.0.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "typescript": "^4.7.4"
   },
   "externals": {

--- a/src/components/CaptchaHeader/CaptchaHeader.tsx
+++ b/src/components/CaptchaHeader/CaptchaHeader.tsx
@@ -1,10 +1,10 @@
-import { Props } from "../../types/index";
+import { SharedProps } from "../../types/index";
 import { CaptchaHeaderDiv } from "./CaptchaHeaderStyles";
 
 interface CaptchaHeaderProps {
-  headerText?: Props.SharedProps["headerText"];
+  headerText?: SharedProps["headerText"];
   captchaTopic: string;
-  verifyText: Props.SharedProps["verifyText"];
+  verifyText: SharedProps["verifyText"];
 }
 
 export const CaptchaHeader = (props: CaptchaHeaderProps) => {

--- a/src/components/FakeCaptcha/FakeCaptcha.tsx
+++ b/src/components/FakeCaptcha/FakeCaptcha.tsx
@@ -14,10 +14,10 @@ import { randomCaptchaTopic } from "../../utils/index";
 import { RefreshSvg } from "../SvgComponent/SvgComponent";
 import { Label } from "../FakeCaptchaButton/FakeCaptchaButtonStyles";
 import { useCallback } from "react";
-import { Props } from "../../types/index";
+import { CaptchaWindowProps } from "../../types/index";
 import { OverlayDiv } from "../Overlay/OverlayStyles";
 
-const FaCAPTCHA = (props: Props.CaptchaWindow) => {
+const FaCAPTCHA = (props: CaptchaWindowProps) => {
   const {
     verifyText = "verify",
     onClickVerify,

--- a/src/components/FakeCaptcha/FakeCaptcha.tsx
+++ b/src/components/FakeCaptcha/FakeCaptcha.tsx
@@ -61,8 +61,8 @@ const FaCAPTCHA = (props: Props.CaptchaWindow) => {
       Math.random() * (simulateSlow * 3000 - simulateSlow * 2000) +
         simulateSlow * 2000
     );
-  let correctSelectionKeys: string[] = [];
-  let selectedItems: string[] = [];
+  const correctSelectionKeys: string[] = [];
+  const selectedItems: string[] = [];
 
   // Simulates initial loading time.
   useEffect(() => {

--- a/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
+++ b/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
@@ -66,7 +66,6 @@ export const FaCaptchaButton = (props: Props.CaptchaButton) => {
             id="captcha-checkbox"
             name="facaptcha-Checkbox"
             checked={checked}
-            onChange={() => {}}
             disabled={isDisabled}
           />
           <label htmlFor="">{notARobotText}</label>

--- a/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
+++ b/src/components/FakeCaptchaButton/FakeCaptchaButton.tsx
@@ -7,9 +7,9 @@ import {
 } from "./FakeCaptchaButtonStyles";
 import FakeCAPTCHA from "../FakeCaptcha/FakeCaptcha";
 import { useEffect } from "react";
-import { Props } from "../../types/index";
+import { CaptchaButtonProps } from "../../types/index";
 
-export const FaCaptchaButton = (props: Props.CaptchaButton) => {
+export const FaCaptchaButton = (props: CaptchaButtonProps) => {
   const {
     allowRetry = false,
     notARobotText = "I'm not a robot",

--- a/src/components/ImageButtons/ImageButtons.tsx
+++ b/src/components/ImageButtons/ImageButtons.tsx
@@ -5,11 +5,11 @@ import {
   ClickableImageContainer,
 } from "./ImageButtonStyles";
 import { CheckmarkSvg } from "../SvgComponent/SvgComponent";
-import { Props } from "../../types/index";
+import { ImgTopicType } from "../../types/index";
 
 interface ImageButtonProps {
-  url: Props.ImgTopicType["url"];
-  topics: Props.ImgTopicType["topics"];
+  url: ImgTopicType["url"];
+  topics: ImgTopicType["topics"];
   handleSelection: (key: string) => void;
   imageKey: string;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
-import Props from "./types/index";
+import { CaptchaButtonProps } from "./types/index";
 import { FaCaptchaButton } from "./components/FakeCaptchaButton/FakeCaptchaButton";
 
-const FaCaptcha = (props: Props.CaptchaButton) => {
+const FaCaptcha = (props: CaptchaButtonProps) => {
   return (
     <span style={{ boxSizing: "border-box" }}>
       <FaCaptchaButton {...props} />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,41 +1,37 @@
-export namespace Props {
-  export type ImgTopicType = {
-    url: string;
-    topics: string[];
-  };
+export type ImgTopicType = {
+  url: string;
+  topics: string[];
+};
 
-  export interface SharedProps {
-    captchaTopics?: string[]; // CAPTCHA topics. Pseudorandom, default values will be used if captchaTopics is not defined.
-    cellsTall?: number; // Number of cells in each column. If not defined, column heights will be equal to row lengths.
-    cellsWide?: number; // Number of cells in each row.
-    headerText?: string; // Used in place of the CAPTCHA header text. Overrides captchaTopic.
-    imgTopicUrls: ImgTopicType[]; // Array of image URLs with associated tags. The tags are compared to captchaTopics and case and spelling must match exactly. The images will be displayed in order.
-    helpText?: string; // An alternative to the default help text, shown when the '?' icon is clicked.
-    minAttempts?: number; // The minimum number of required attempts, regardless of whether the attempts are correct or not.
-    maxAttempts?: number; // The maximum number of attempts that can be made before being denied access. Must be greater than or equal to minAttempts.
-    onClickVerify?: () => void; // Function to execute on clicking 'Verify'.
-    onMaxAttempts?: () => void; // Function called when the user has met the maximum number of attempts.
-    onRefresh?: () => void; // Executes on clicking the refresh icon.
-    simulateSlow?: 0 | 1 | 2 | 3; // Simulate a slow internet connection.
-    uncloseable?: boolean; // Prevent the CAPTCHA from being closed until verification is complete.
-    verifyText?: string; // Text for the 'Verify' button.
-  }
-
-  export interface CaptchaButton extends SharedProps {
-    allowRetry?: boolean; // Allows the users to retry the CAPTCHA if they press the checkmark again.
-    disabled?: boolean; // Disables the checkbox and disallows the user to complete verification.
-    notARobotText?: string; // Used in place of "I'm not a robot".
-    onClickCheckbox?: () => void; // Executes on clicking the checkbox, does not execute if the CAPTCHA popup is open.
-    onVerificationComplete: () => void; // Sets verified state on completion.
-  }
-
-  export interface CaptchaWindow extends SharedProps {
-    poweredByText: string;
-    captchaPassed: boolean;
-    setCaptchaPassed: (value: boolean) => void;
-    setShowCaptcha: (value: boolean) => void;
-    setDisabled: (value: boolean) => void;
-  }
+export interface SharedProps {
+  captchaTopics?: string[]; // CAPTCHA topics. Pseudorandom, default values will be used if captchaTopics is not defined.
+  cellsTall?: number; // Number of cells in each column. If not defined, column heights will be equal to row lengths.
+  cellsWide?: number; // Number of cells in each row.
+  headerText?: string; // Used in place of the CAPTCHA header text. Overrides captchaTopic.
+  imgTopicUrls: ImgTopicType[]; // Array of image URLs with associated tags. The tags are compared to captchaTopics and case and spelling must match exactly. The images will be displayed in order.
+  helpText?: string; // An alternative to the default help text, shown when the '?' icon is clicked.
+  minAttempts?: number; // The minimum number of required attempts, regardless of whether the attempts are correct or not.
+  maxAttempts?: number; // The maximum number of attempts that can be made before being denied access. Must be greater than or equal to minAttempts.
+  onClickVerify?: () => void; // Function to execute on clicking 'Verify'.
+  onMaxAttempts?: () => void; // Function called when the user has met the maximum number of attempts.
+  onRefresh?: () => void; // Executes on clicking the refresh icon.
+  simulateSlow?: 0 | 1 | 2 | 3; // Simulate a slow internet connection.
+  uncloseable?: boolean; // Prevent the CAPTCHA from being closed until verification is complete.
+  verifyText?: string; // Text for the 'Verify' button.
 }
 
-export default Props;
+export interface CaptchaButtonProps extends SharedProps {
+  allowRetry?: boolean; // Allows the users to retry the CAPTCHA if they press the checkmark again.
+  disabled?: boolean; // Disables the checkbox and disallows the user to complete verification.
+  notARobotText?: string; // Used in place of "I'm not a robot".
+  onClickCheckbox?: () => void; // Executes on clicking the checkbox, does not execute if the CAPTCHA popup is open.
+  onVerificationComplete: () => void; // Sets verified state on completion.
+}
+
+export interface CaptchaWindowProps extends SharedProps {
+  poweredByText: string;
+  captchaPassed: boolean;
+  setCaptchaPassed: (value: boolean) => void;
+  setShowCaptcha: (value: boolean) => void;
+  setDisabled: (value: boolean) => void;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,6 +94,11 @@
     "@emotion/weak-memoize" "^0.3.0"
     stylis "4.0.13"
 
+"@emotion/eslint-plugin@^11.10.0":
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/eslint-plugin/-/eslint-plugin-11.10.0.tgz#e0d8544c8a568bb2dac605b87346baaa3b846e80"
+  integrity sha512-nWpuoQQrzI9aM9fgn+Pbb0pOau4BhheXyVqHcOYKFq46uSuSR2ivZaDwwCJKI6ScA8Pm7OcoOpwdRH2iisf9cg==
+
 "@emotion/hash@^0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
@@ -686,6 +691,11 @@ eslint-plugin-jsx-a11y@^6.6.1:
     language-tags "^1.0.5"
     minimatch "^3.1.2"
     semver "^6.3.0"
+
+eslint-plugin-react-hooks@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
 eslint-plugin-react@^7.30.1:
   version "7.30.1"
@@ -1469,11 +1479,6 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
-
-react-hooks@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-hooks/-/react-hooks-1.0.1.tgz#e62197c38cd8d0703060f791234f7f4698aa7c44"
-  integrity sha512-PXU08tw4SvKwkW99qgnyV98x939RCmBC6aXqALPQXPjKq6+6EoH79Rz4KdUozzlpSyWmn2IiEm0vh3p+79aP5w==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
### Summary
Fixes the eslint config and problems reported by eslint. Added a command to run eslint on files in `src`, `yarn eslint`.

⚠Contains potentially breaking changes, as the prop types have been renamed and are no longer part of an exported namespace named 'props', they are simply exported individually. This change was made to comply with the [@typescript-eslint/no-namespace](https://typescript-eslint.io/rules/no-namespace/) rule, as ES2015 module syntax is preferred over custom TypeScript namespaces. 

⚠The following props interface name changes were made:
* `CaptchaButton` to `CaptchaButtonProps`
* `CaptchaWindow` to `CaptchaWindowProps`

They are still currently exported from the same file.


### Why this change is needed
eslint was not properly set up and thus was not working.

### What was done
Fixed the config, added new rules and dependencies.
